### PR TITLE
Make '/' redirect to '/client/dashboard' if user is authenticated

### DIFF
--- a/src/main/java/de/fau/amos4/annotation/TheClient.java
+++ b/src/main/java/de/fau/amos4/annotation/TheClient.java
@@ -1,0 +1,33 @@
+/**
+ * Personalfragebogen 2.0. Revolutionize form data entry for taxation and
+ * other purposes.
+ * Copyright (C) 2015 Attila Bujaki, Werner Sembach, Jonas Gröger, Oswaldo
+ *     Bejarano, Ardhi Sutadi, Nikitha Mohan, Benedikt Rauh
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.fau.amos4.annotation;
+
+import org.springframework.security.web.bind.annotation.AuthenticationPrincipal;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@AuthenticationPrincipal
+public @interface TheClient
+{
+
+}

--- a/src/test/java/de/fau/amos4/test/integration/ClientTest.java
+++ b/src/test/java/de/fau/amos4/test/integration/ClientTest.java
@@ -2,7 +2,7 @@
  * Personalfragebogen 2.0. Revolutionize form data entry for taxation and
  * other purposes.
  * Copyright (C) 2015 Attila Bujaki, Werner Sembach, Jonas Gröger, Oswaldo
- * Bejarano, Ardhi Sutadi, Nikitha Mohan, Benedikt Rauh
+ *     Bejarano, Ardhi Sutadi, Nikitha Mohan, Benedikt Rauh
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -19,16 +19,13 @@
  */
 package de.fau.amos4.test.integration;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
-
+import de.fau.amos4.test.BaseIntegrationTest;
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.security.test.context.support.WithUserDetails;
 
-import de.fau.amos4.test.BaseIntegrationTest;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 public class ClientTest extends BaseIntegrationTest
 {
@@ -37,7 +34,7 @@ public class ClientTest extends BaseIntegrationTest
     {
         mockMvc.perform(get("/"))
                 .andExpect(status().isOk())
-                .andExpect(view().name("client/login"));
+                .andExpect(view().name("/client/login"));
     }
 
     @Test
@@ -96,7 +93,7 @@ public class ClientTest extends BaseIntegrationTest
     {
         mockMvc.perform(get("/client/dashboard"))
                 .andExpect(status().isOk())
-                .andExpect(view().name("client/dashboard"));
+                .andExpect(view().name("/client/dashboard"));
     }
 
     @Test
@@ -113,6 +110,6 @@ public class ClientTest extends BaseIntegrationTest
     {
         mockMvc.perform(get("/client/edit"))
                 .andExpect(status().isOk())
-                .andExpect(view().name("client/edit"));
+                .andExpect(view().name("/client/edit"));
     }
 }

--- a/src/test/java/de/fau/amos4/test/unit/ClientControllerUnitTest.java
+++ b/src/test/java/de/fau/amos4/test/unit/ClientControllerUnitTest.java
@@ -19,18 +19,17 @@
  */
 package de.fau.amos4.test.unit;
 
-import java.security.Principal;
-
+import com.sun.security.auth.UserPrincipal;
+import de.fau.amos4.model.Client;
+import de.fau.amos4.model.CurrentClient;
+import de.fau.amos4.model.Employee;
+import de.fau.amos4.test.BaseWebApplicationContextTests;
+import de.fau.amos4.web.ClientController;
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.web.servlet.ModelAndView;
 
-import com.sun.security.auth.UserPrincipal;
-
-import de.fau.amos4.model.Client;
-import de.fau.amos4.model.Employee;
-import de.fau.amos4.test.BaseWebApplicationContextTests;
-import de.fau.amos4.web.ClientController;
+import java.security.Principal;
 
 public class ClientControllerUnitTest extends BaseWebApplicationContextTests
 {
@@ -38,23 +37,20 @@ public class ClientControllerUnitTest extends BaseWebApplicationContextTests
      * Test client dashboard: Make sure that each Employee displayed in the dashboard really belongs to the actual client.
      */
     @Test
-    public void clientDashboard_OnlyClientsEmployeesAreDisplayrd() throws Exception
+    public void clientDashboard_OnlyClientsEmployeesAreDisplayed() throws Exception
     {
-        // Instantiate the controller
         ClientController clientController = new ClientController(this.clientService, this.employeeRepository, translatorService);
-        // Get a client's username
-        String UserName = this.clientService.getClientById(1l).getEmail();
-        
+        final Client client = this.clientService.getClientById(1l);
+
         // Get the List
-        Principal principal = new UserPrincipal(UserName);
-        ModelAndView mav = clientController.ClientDashboard(principal);
+        ModelAndView mav = clientController.ClientDashboard(new CurrentClient(client));
         
         // Model should contain only employees with this client.
-        Iterable<Employee> employees = (Iterable<Employee>)mav.getModel().get("Employees");
+        Iterable<Employee> employees = (Iterable<Employee>) mav.getModel().get("Employees");
         for(Employee employee : employees)
         {
             // Make sure that each Employee belongs to the current client.
-            Assert.assertEquals(UserName, employee.getClient().getEmail());
+            Assert.assertEquals(client.getEmail(), employee.getClient().getEmail());
         }
     }
     
@@ -74,10 +70,10 @@ public class ClientControllerUnitTest extends BaseWebApplicationContextTests
         
         // Get the List
         Principal principal = new UserPrincipal(UserName);
-        ModelAndView mav = clientController.ClientDashboard(principal);
+        ModelAndView mav = clientController.ClientDashboard(new CurrentClient(client));
         
         // Model should contain only employees with this client.
-        Iterable<Employee> employees = (Iterable<Employee>)mav.getModel().get("Employees");
+        Iterable<Employee> employees = (Iterable<Employee>) mav.getModel().get("Employees");
         
         // Count original employee count
         int originalEmployeeCount = 0;
@@ -92,10 +88,10 @@ public class ClientControllerUnitTest extends BaseWebApplicationContextTests
         employeeRepository.save(newEmployee);
         
         // Get new employee list
-        mav = clientController.ClientDashboard(principal);
+        mav = clientController.ClientDashboard(new CurrentClient(client));
         
         // Model should contain only employees with this client.
-        employees = (Iterable<Employee>)mav.getModel().get("Employees");
+        employees = (Iterable<Employee>) mav.getModel().get("Employees");
         
         // Count new employee count
         int newEmployeeCount = 0;


### PR DESCRIPTION
I created a new annotation @TheClient which can be used instead of the
@AuthentificationPrincipal annotation. This allows for less spring
security code in our web layer. This annotation is then used in
deciding if the user is logged in or not.

For consistency all other routes now use this annotation as well.

This broke some (already fixed) tests because various routes expected to
get a Principal but now get a CurrentClient, which hides Spring
Security in tests as well.
