### PR TITLE
LODAS export fail bug fixed

### DIFF
--- a/src/main/java/de/fau/amos4/web/PrintDataController.java
+++ b/src/main/java/de/fau/amos4/web/PrintDataController.java
@@ -74,10 +74,11 @@ public class PrintDataController
         // We want to have a txt file download
         response.setContentType("text/plain");
         response.setHeader("Content-Disposition", "attachment;filename=employee_as_lodas.txt");
+        response.setCharacterEncoding("UTF-8");
 
         // Write the data out
         ServletOutputStream out = response.getOutputStream();
-        out.print(employeeAsLodas);
+        out.write(employeeAsLodas.getBytes());
         out.flush();
         out.close();
         return null;

--- a/src/test/java/de/fau/amos4/test/integration/EmployeeTest.java
+++ b/src/test/java/de/fau/amos4/test/integration/EmployeeTest.java
@@ -52,7 +52,6 @@ public class EmployeeTest extends BaseIntegrationTest
     // Make sure that download employee data as text file feature works as expected. (A text file should be downloaded.)
     @Test
     @WithUserDetails("datev@example.com")
-    @Ignore // TODO: FIXME - Issue opened: https://github.com/JOBAA/amos-ss15-proj4/issues/101
     public void testEmployeeAsLodasFileDownload() throws Exception
     {
         final MockHttpServletResponse response = mockMvc.perform(get("/employee/download/text").param("id", "2"))


### PR DESCRIPTION
- Instead of exporting text, now the text content is converted to bytes, so the special UTF-8 cahrs are not causing an unexpected exception anymore.
